### PR TITLE
Fix "Terracotta Connect" 403 Error on cloudflare-protected servers.

### DIFF
--- a/terracotta/scripts/connect.py
+++ b/terracotta/scripts/connect.py
@@ -29,10 +29,6 @@ def build_request(url: str) -> urllib.request.Request:
         "User-Agent",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:106.0) Gecko/20100101 Firefox/106.0",
     )
-    req.add_header(
-        "Accept",
-        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-    )
     return req
 
 

--- a/terracotta/scripts/connect.py
+++ b/terracotta/scripts/connect.py
@@ -20,6 +20,22 @@ from terracotta.scripts.click_types import Hostname
 from terracotta.scripts.http_utils import find_open_port
 
 
+def build_request(url: str) -> urllib.request.Request:
+    """
+    Build a request object with headers that mimic a web browser.
+    """
+    req = urllib.request.Request(url)
+    req.add_header(
+        "User-Agent",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:106.0) Gecko/20100101 Firefox/106.0",
+    )
+    req.add_header(
+        "Accept",
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    )
+    return req
+
+
 @click.command(
     "connect",
     short_help="Connect to a running Terracotta instance and interactively "
@@ -49,9 +65,8 @@ def connect(
 
     # check if remote host is running Terracotta
     test_url = f"{terracotta_hostname}/keys"
-
     try:
-        with urllib.request.urlopen(test_url, timeout=5):
+        with urllib.request.urlopen(build_request(test_url), timeout=5):
             pass
     except (HTTPError, URLError, socket.timeout):
         click.echo(
@@ -63,7 +78,7 @@ def connect(
 
     # catch version incompatibility
     spec_url = f"{terracotta_hostname}/swagger.json"
-    with urllib.request.urlopen(spec_url, timeout=5) as response:
+    with urllib.request.urlopen(build_request(spec_url), timeout=5) as response:
         spec = json.loads(response.read())
 
     def versiontuple(version_string: str) -> Sequence[str]:

--- a/terracotta/scripts/connect.py
+++ b/terracotta/scripts/connect.py
@@ -23,6 +23,8 @@ from terracotta.scripts.http_utils import find_open_port
 def build_request(url: str) -> urllib.request.Request:
     """
     Build a request object with headers that mimic a web browser.
+    This is for example needed to bypass cloudflare protection for automated scraping,
+    in the case where terracotta is behind the cloudflare proxy.
     """
     req = urllib.request.Request(url)
     req.add_header(


### PR DESCRIPTION
Hi all,

After successfully deploying Terracotta , I noticed terracotta connect was no longer working when querying through cloudflare. It seems like cloudflare blocks the urllib user-agent by default and throws a 403 code.

Following [this stackoverflow suggestion](https://stackoverflow.com/questions/74446830/how-to-fix-403-forbidden-errors-with-python-requests-even-with-user-agent-head), I resolved this problem by mimicking a browser by setting the appropriate headers.

This is my first time making a pull-request, so please let me know if I am doing this the wrong way and/or if I should improve something.

Cheers!