### PR TITLE
Update PyPI workflow to use trusted publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,20 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/terracotta
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # make sure tags are fetched so we can get a version
       - run: |
           git fetch --prune --unshallow --tags
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
@@ -31,6 +35,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Recent failure in PyPI publication workflow on release v0.8.4 was due an issue with my PyPI account, but I am using this occasion to update the workflow to follow [latest recommendations](https://github.com/marketplace/actions/pypi-publish).

Addresses
- #341 