### PR TITLE
remove upper bound from numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "tqdm",
     ],
     extras_require={
+        ':python_version == "3.9"': ["numpy<2.0.0"],
         "test": [
             "pytest",
             "pytest-cov",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ long_description = re.sub(
 numpy_constraints = (
     ">=1.15",
     "!=1.17.0",
-    # TODO: drop this once all deps support numpy 2.0
-    # see https://github.com/dask/crick/issues/53
-    "<2",
 )
 numpy_version = ",".join(numpy_constraints)
 


### PR DESCRIPTION
https://github.com/dask/crick/issues/53 was resolved and tests pass locally for me.

This is causing issues for us since other packages started requiring `numpy>=2.0`