### PR TITLE
Install packages in docker container to enable flask profiling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,8 @@ RUN pip install --no-cache-dir --upgrade pip \
         pymysql>=1.0.0 \
         psycopg2-binary \
         gunicorn \
-        werkzeug==0.16.0 \
-        markupsafe==2.0.1 \
+        werkzeug<=0.16.0 \
+        markupsafe<=2.0.1 \
     && rm -rf /terracotta
 
 COPY docker/resources /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,8 @@ RUN pip install --no-cache-dir --upgrade pip \
         pymysql>=1.0.0 \
         psycopg2-binary \
         gunicorn \
+        werkzeug==0.16.0 \
+        markupsafe==2.0.1 \
     && rm -rf /terracotta
 
 COPY docker/resources /

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,8 @@ RUN pip install --no-cache-dir --upgrade pip \
         pymysql>=1.0.0 \
         psycopg2-binary \
         gunicorn \
-        werkzeug<=0.16.0 \
-        markupsafe<=2.0.1 \
+        werkzeug==0.16.0 \
+        markupsafe==2.0.1 \
     && rm -rf /terracotta
 
 COPY docker/resources /


### PR DESCRIPTION
Currently setting `FLASK_PROFILE=true` when using the docker container fails due to missing packages.

This PR adds the packages necessary to run flask profiling.

They are unfortunately quite dated - these are the maximum versions that I found would succeed with no other code changes. I'm happy to modify if there is a clear path profiling with more up-to-date packages.