### PR TITLE
Allows RasterIO to read GeoTiffs from S3 object stores requiring authentication

### DIFF
--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -136,7 +136,7 @@ class SettingSchema(Schema):
 
     RASTER_CACHE_SIZE = fields.Integer(validate=validate.Range(min=0))
     RASTER_CACHE_COMPRESS_LEVEL = fields.Integer(validate=validate.Range(min=0, max=9))
-    
+
     RASTER_AWS_ACCESS_KEY = fields.String(allow_none=True)
     RASTER_AWS_SECRET_KEY = fields.String(allow_none=True)
     RASTER_AWS_S3_ENDPOINT = fields.String(allow_none=True)

--- a/terracotta/config.py
+++ b/terracotta/config.py
@@ -41,6 +41,15 @@ class TerracottaSettings(NamedTuple):
     #: Compression level of raster file in-memory cache, from 0-9
     RASTER_CACHE_COMPRESS_LEVEL: int = 9
 
+    #: The Access Key for the S3 bucket of the RasterStore:
+    RASTER_AWS_ACCESS_KEY: Optional[str] = None
+
+    #: The Secret Key for the S3 bucket of the RasterStore:
+    RASTER_AWS_SECRET_KEY: Optional[str] = None
+
+    #: The S3:// endpoint for the S3 server of the RaterStore:
+    RASTER_AWS_S3_ENDPOINT: Optional[str] = None
+
     #: Tile size to return if not given in parameters
     DEFAULT_TILE_SIZE: Tuple[int, int] = (256, 256)
 
@@ -127,6 +136,10 @@ class SettingSchema(Schema):
 
     RASTER_CACHE_SIZE = fields.Integer(validate=validate.Range(min=0))
     RASTER_CACHE_COMPRESS_LEVEL = fields.Integer(validate=validate.Range(min=0, max=9))
+    
+    RASTER_AWS_ACCESS_KEY = fields.String(allow_none=True)
+    RASTER_AWS_SECRET_KEY = fields.String(allow_none=True)
+    RASTER_AWS_S3_ENDPOINT = fields.String(allow_none=True)
 
     DEFAULT_TILE_SIZE = fields.List(fields.Integer(), validate=validate.Length(equal=2))
 

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -140,10 +140,11 @@ class GeoTiffRasterStore(RasterStore):
             rio_env_options=self._RIO_ENV_OPTIONS
         )
         
-        if hasattr(settings, "RASTER_AWS_S3_ENDPOINT"):
-            kwargs.update(
-                aws_s3_endpoint=settings.RASTER_AWS_S3_ENDPOINT
-            ) 
+        try: 
+            kwargs.update(aws_s3_endpoint=settings.RASTER_AWS_S3_ENDPOINT)
+        except AttributeError:
+            pass
+             
 
         cache_key = hash(ensure_hashable(kwargs))
 

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -130,6 +130,15 @@ class GeoTiffRasterStore(RasterStore):
         if tile_size is None:
             tile_size = settings.DEFAULT_TILE_SIZE
 
+        if settings.RASTER_AWS_ACCESS_KEY is not None:
+            self._RIO_ENV_OPTIONS = self._RIO_ENV_OPTIONS.update(
+                AWS_VIRTUAL_HOSTING=False,
+                AWS_HTTPS='NO',
+                AWS_S3_ENDPOIN=settings.RASTER_AWS_S3_ENDPOINT,
+                AWS_ACCESS_KEY_ID=settings.RASTER_AWS_ACCESS_KEY,
+                AWS_SECRET_ACCESS_KEY=settings.RASTER_AWS_SECRET_KEY
+            )
+
         kwargs = dict(
             path=path,
             tile_bounds=tile_bounds,

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -140,10 +140,8 @@ class GeoTiffRasterStore(RasterStore):
             rio_env_options=self._RIO_ENV_OPTIONS
         )
         
-        try: 
+        if settings.RASTER_AWS_S3_ENDPOINT is not None:
             kwargs.update(aws_s3_endpoint=settings.RASTER_AWS_S3_ENDPOINT)
-        except AttributeError:
-            pass
              
 
         cache_key = hash(ensure_hashable(kwargs))

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -74,7 +74,6 @@ def ensure_hashable(val: Any) -> Any:
 
     return val
 
-
 class GeoTiffRasterStore(RasterStore):
     """Raster store that operates on GeoTiff raster files from disk.
 
@@ -130,15 +129,6 @@ class GeoTiffRasterStore(RasterStore):
         if tile_size is None:
             tile_size = settings.DEFAULT_TILE_SIZE
 
-        if settings.RASTER_AWS_S3_ENDPOINT is not None:
-            
-            # Have to use this as AWSSession/boto3.Session is not seralizable:
-            self._RIO_ENV_OPTIONS.update(
-                AWS_ACCESS_KEY=settings.RASTER_AWS_ACCESS_KEY,
-                AWS_SECRET_KEY=settings.RASTER_AWS_SECRET_KEY,
-                AWS_S3_ENDPOINT=settings.RASTER_AWS_S3_ENDPOINT
-            )
-        
         kwargs = dict(
             path=path,
             tile_bounds=tile_bounds,
@@ -147,8 +137,13 @@ class GeoTiffRasterStore(RasterStore):
             reprojection_method=settings.REPROJECTION_METHOD,
             resampling_method=settings.RESAMPLING_METHOD,
             target_crs=self._TARGET_CRS,
-            rio_env_options=self._RIO_ENV_OPTIONS,
+            rio_env_options=self._RIO_ENV_OPTIONS
         )
+        
+        if hasattr(settings, "RASTER_AWS_S3_ENDPOINT"):
+            kwargs.update(
+                aws_s3_endpoint=settings.RASTER_AWS_S3_ENDPOINT
+            ) 
 
         cache_key = hash(ensure_hashable(kwargs))
 

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -74,6 +74,7 @@ def ensure_hashable(val: Any) -> Any:
 
     return val
 
+
 class GeoTiffRasterStore(RasterStore):
     """Raster store that operates on GeoTiff raster files from disk.
 
@@ -137,12 +138,17 @@ class GeoTiffRasterStore(RasterStore):
             reprojection_method=settings.REPROJECTION_METHOD,
             resampling_method=settings.RESAMPLING_METHOD,
             target_crs=self._TARGET_CRS,
-            rio_env_options=self._RIO_ENV_OPTIONS
+            rio_env_options=self._RIO_ENV_OPTIONS,
         )
-        
+
         if settings.RASTER_AWS_S3_ENDPOINT is not None:
-            kwargs.update(aws_s3_endpoint=settings.RASTER_AWS_S3_ENDPOINT)
-             
+            kwargs.update(
+                aws_s3_config=dict(
+                    aws_access_key_id=settings.RASTER_AWS_ACCESS_KEY,
+                    aws_secret_access_key=settings.RASTER_AWS_SECRET_KEY,
+                    endpoint_url=settings.RASTER_AWS_S3_ENDPOINT,
+                )
+            )
 
         cache_key = hash(ensure_hashable(kwargs))
 

--- a/terracotta/drivers/geotiff_raster_store.py
+++ b/terracotta/drivers/geotiff_raster_store.py
@@ -130,15 +130,15 @@ class GeoTiffRasterStore(RasterStore):
         if tile_size is None:
             tile_size = settings.DEFAULT_TILE_SIZE
 
-        if settings.RASTER_AWS_ACCESS_KEY is not None:
-            self._RIO_ENV_OPTIONS = self._RIO_ENV_OPTIONS.update(
-                AWS_VIRTUAL_HOSTING=False,
-                AWS_HTTPS='NO',
-                AWS_S3_ENDPOIN=settings.RASTER_AWS_S3_ENDPOINT,
-                AWS_ACCESS_KEY_ID=settings.RASTER_AWS_ACCESS_KEY,
-                AWS_SECRET_ACCESS_KEY=settings.RASTER_AWS_SECRET_KEY
+        if settings.RASTER_AWS_S3_ENDPOINT is not None:
+            
+            # Have to use this as AWSSession/boto3.Session is not seralizable:
+            self._RIO_ENV_OPTIONS.update(
+                AWS_ACCESS_KEY=settings.RASTER_AWS_ACCESS_KEY,
+                AWS_SECRET_KEY=settings.RASTER_AWS_SECRET_KEY,
+                AWS_S3_ENDPOINT=settings.RASTER_AWS_S3_ENDPOINT
             )
-
+        
         kwargs = dict(
             path=path,
             tile_bounds=tile_bounds,

--- a/terracotta/raster.py
+++ b/terracotta/raster.py
@@ -32,9 +32,8 @@ def get_aws_session() -> Union[AWSSession, None]:
 
     settings = get_settings()
 
-    if hasattr(settings, "RASTER_AWS_S3_ENDPOINT"):
+    try:
         import boto3
-
         aws_session = AWSSession(
             boto3.Session(
                 aws_access_key_id=settings.RASTER_AWS_ACCESS_KEY,
@@ -43,8 +42,8 @@ def get_aws_session() -> Union[AWSSession, None]:
             endpoint_url=settings.RASTER_AWS_S3_ENDPOINT
         )
         return aws_session
-
-    return None
+    except AttributeError:
+        return None
 
 
 def convex_hull_candidate_mask(mask: np.ndarray) -> np.ndarray:

--- a/terracotta/raster.py
+++ b/terracotta/raster.py
@@ -28,7 +28,7 @@ from terracotta.profile import trace
 logger = logging.getLogger(__name__)
 
 @functools.cache
-def get_aws_session() -> Union[AWSSession, None]:
+def get_aws_session(RASTER_AWS_S3_ENDPOINT: str) -> Union[AWSSession, None]:
 
     settings = get_settings()
 
@@ -342,7 +342,7 @@ def get_raster_tile(
             AWS_VIRTUAL_HOSTING=False,
             AWS_HTTPS='NO',
             GDAL_DISABLE_READDIR_ON_OPEN='YES',
-            session=get_aws_session()
+            session=get_aws_session(aws_s3_endpoint)
         )
 
     if preserve_values:


### PR DESCRIPTION
Added support for reading Geotiff files from an S3 object store that requires authentication via a secret key and access key.

Added the config variables required to enable auth S3 reading and based on the presence of these config params creates a boto3 AWSSession object to be passed through to the rasterio.Env context.