### PR TITLE
fix pillow deprecation warning for mode argument in fromarray

### DIFF
--- a/terracotta/image.py
+++ b/terracotta/image.py
@@ -41,12 +41,10 @@ def array_to_png(
         if colormap is not None:
             raise ValueError("Colormap argument cannot be given for multi-band data")
 
-        mode = "RGB"
         transparency = (0, 0, 0)
         palette = None
 
     elif img_data.ndim == 2:  # encode paletted image
-        mode = "L"
 
         if colormap is None:
             palette = None
@@ -106,7 +104,7 @@ def array_to_png(
     if isinstance(img_data, np.ma.MaskedArray):
         img_data = img_data.filled(0)
 
-    img = Image.fromarray(img_data, mode=mode)
+    img = Image.fromarray(img_data)
 
     if palette is not None:
         img.putpalette(palette)


### PR DESCRIPTION
This parameter is scheduled for removal: https://pillow.readthedocs.io/en/latest/deprecations.html#image-fromarray-mode-parameter

They state:

> The mode can be automatically determined from the object’s shape and type instead.

Simply removing it does the trick. This is covered by tests which still pass.